### PR TITLE
Add detail to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,15 +2,16 @@
 
 [Tailscale](https://tailscale.com) is a zero-config VPN service built on top of [Wireguard](https://www.wireguard.com/). It's great for accessing devices and applications behind firewalls, and you can use it to connect to all your private services on Render with this repo.
 
-Tailscale [subnet routers](https://tailscale.com/kb/1019/subnets/) act as a gateway to your Render private network, enabling connections to any and all internal IPs (of the form `10.x.x.x`) in your Render network.
+A Tailscale [subnet router](https://tailscale.com/kb/1019/subnets/) acts as a gateway to your Render private network, enabling connections to any and all internal IPs (of the form `10.x.x.x`) in your Render network.
 
 ## Deployment
 
 ### One Click Deploy
 
-Use the button below to deploy a Tailscale Subnet Router on Render.
+Use the button below to deploy a Tailscale subnet router on Render. [Generate a Tailscale auth key](https://login.tailscale.com/admin/settings/authkeys) and enter it when prompted. Use a one-off key for maximum security.
 
 [![Deploy to Render](http://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy)
 
 ## Usage
-Deploying this repo will create a subnet router in your Tailscale network. Once it's up and running, you can connect to any private service by looking up $RENDER_INTERNAL_IP in the web shell.
+Deploying this repo will create a subnet router in your Tailscale network. The first time you deploy, you'll need to [enable the subnet routes](https://tailscale.com/kb/1019/subnets/#step-3-enable-subnet-routes-from-the-admin-panel) you want access to from the Tailscale admin panel. Once the subnet router is up and running, you can connect to other private services in your Render network. To find the internal IP address for a Render private service, go to the web shell for your subnet router service and run `dig` with the [private service's host name](https://render.com/docs/private-services#connecting-to-a-private-service) as the only argument.
+


### PR DESCRIPTION
Highlighting the key changes:

- Recommend using a one-off key
- Use `dig` to get the IP address for the service, rather than `RENDER_INTERNAL_IP` to get the IP address for a particular instance. The former is more stable.