### PR TITLE
Bump Tailscale version to 1.14.3

### DIFF
--- a/install-tailscale.sh
+++ b/install-tailscale.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -x
-TAILSCALE_VERSION=${TAILSCALE_VERSION:-1.14.0}
+TAILSCALE_VERSION=${TAILSCALE_VERSION:-1.14.3}
 TS_FILE=tailscale_${TAILSCALE_VERSION}_amd64.tgz
 wget -q "https://pkgs.tailscale.com/stable/${TS_FILE}" && tar xzf "${TS_FILE}" --strip-components=1
 cp -r tailscale tailscaled /usr/bin/

--- a/render.yaml
+++ b/render.yaml
@@ -6,7 +6,7 @@ services:
       - key: TAILSCALE_AUTHKEY
         sync: false
       - key: TAILSCALE_VERSION
-        value: 1.14.0
+        value: 1.14.3
       - key: ADVERTISE_ROUTES
         value: 10.0.0.0/8
     disk:


### PR DESCRIPTION
Release notes: https://github.com/tailscale/tailscale/releases/tag/v1.14.3