### PR TITLE
Bump Tailscale to v1.22.0

### DIFF
--- a/install-tailscale.sh
+++ b/install-tailscale.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -x
-TAILSCALE_VERSION=${TAILSCALE_VERSION:-1.16.1}
+TAILSCALE_VERSION=${TAILSCALE_VERSION:-1.22.0}
 TS_FILE=tailscale_${TAILSCALE_VERSION}_amd64.tgz
 wget -q "https://pkgs.tailscale.com/stable/${TS_FILE}" && tar xzf "${TS_FILE}" --strip-components=1
 cp -r tailscale tailscaled /render/

--- a/render.yaml
+++ b/render.yaml
@@ -6,7 +6,7 @@ services:
       - key: TAILSCALE_AUTHKEY
         sync: false
       - key: TAILSCALE_VERSION
-        value: 1.16.1
+        value: 1.22.0
       - key: ADVERTISE_ROUTES
         value: 10.0.0.0/8
     disk:


### PR DESCRIPTION
1. Test this branch by initiating a Blueprint deploy using this link: https://render.com/deploy?repo=https://github.com/render-examples/tailscale/tree/crc/bump-tailscale-v1.22.0
2. Once deploy is complete, from the Tailscale **Machines** tab, enable the `10.0.0.0/8` route for this new machine.
3. From the **SSH** tab in the Render Dashboard for this service, run `dig some-service`, where `some-service` is the internal hostname of a different Web Service running in your Render account.
4. Using the IP address provided by the previous command, locally run `curl -v IP_ADDRESS:10000` (verify the port; it may be different). This assumes you have Tailscale running locally.

You should get a 200 response, which proves that the curl request was routed to the tailscale subnet router Private Service and then routed to the other Web Service within your Render account.

