### PR TITLE
Make TAILSCALE_VERSION environment variable work

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 FROM debian:latest
 WORKDIR /render
 
+ARG TAILSCALE_VERSION
+ENV TAILSCALE_VERSION=$TAILSCALE_VERSION
+
 RUN apt-get -qq update \
   && apt-get -qq install --upgrade -y --no-install-recommends \
     apt-transport-https \


### PR DESCRIPTION
This fixes #5 by defining the `TAILSCALE_VERSION` build argument in the Dockerfile and using its value to set an environment variable with the same name so that the install script picks it up.