### PR TITLE
Fix netcat dependency that causes build to fail

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get -qq update \
   && apt-get -qq install --upgrade -y --no-install-recommends \
     apt-transport-https \
     ca-certificates \
-    netcat \
+    netcat-traditional \
     wget \
     dnsutils \
   > /dev/null \

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get -qq update \
   && apt-get -qq install --upgrade -y --no-install-recommends \
     apt-transport-https \
     ca-certificates \
-    netcat-traditional \
+    netcat-openbsd \
     wget \
     dnsutils \
   > /dev/null \


### PR DESCRIPTION
On Debian, netcat isn’t a package, as two “variations” of netcat exist in the package repository. So replaced netcat with netcat-traditional.

Prior, build failed with error "Package 'netcat' has no installation candidate"