### PR TITLE
chore: bump Tailscale stable client to 1.96.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ A Tailscale [subnet router](https://tailscale.com/kb/1019/subnets/) acts as a ga
 
 Use the button below to deploy a Tailscale subnet router on Render. [Generate a Tailscale auth key](https://login.tailscale.com/admin/settings/authkeys) and provide that as the `TAILSCALE_AUTHKEY` environment variable in Render. Use a one-off key for maximum security.
 
+The build downloads a static Linux binary from the Tailscale [stable track](https://pkgs.tailscale.com/stable/). Pin the release with `TAILSCALE_VERSION` (set in `render.yaml` for Blueprint deploys, or override in the Render dashboard). Bump it when you want to pick up a newer stable client.
+
 <a href="https://render.com/deploy?repo=https://github.com/render-examples/tailscale/tree/main">
   <img src="https://render.com/images/deploy-to-render-button.svg" alt="Deploy to Render">
 </a>

--- a/install-tailscale.sh
+++ b/install-tailscale.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -x
-TAILSCALE_VERSION=${TAILSCALE_VERSION:-1.64.0}
+TAILSCALE_VERSION=${TAILSCALE_VERSION:-1.96.4}
 TS_FILE=tailscale_${TAILSCALE_VERSION}_amd64.tgz
 wget -q "https://pkgs.tailscale.com/stable/${TS_FILE}" && tar xzf "${TS_FILE}" --strip-components=1
 cp -r tailscale tailscaled /render/

--- a/render.yaml
+++ b/render.yaml
@@ -7,7 +7,7 @@ services:
       - key: TAILSCALE_AUTHKEY
         sync: false
       - key: TAILSCALE_VERSION
-        value: 1.64.0
+        value: 1.96.4
       - key: ADVERTISE_ROUTES
         value: 10.0.0.0/8
     disk:


### PR DESCRIPTION
## Summary

Updates the pinned Tailscale **stable** static tarball from **1.64.0** to **1.96.4** so Blueprint and Docker builds use a current client. Adds a short README note on `TAILSCALE_VERSION` and the [stable track](https://pkgs.tailscale.com/stable/).

## Changes

- **`install-tailscale.sh`:** default `TAILSCALE_VERSION` → **1.96.4** (still overridable at build time).
- **`render.yaml`:** Blueprint `TAILSCALE_VERSION` matches the same value.
- **`README.md`:** documents that the image pulls from the stable tarball and that `TAILSCALE_VERSION` pins the release.

## Testing

- Image builds successfully.
- Runtime logs or `tailscale version` show **1.96.4** after deploy 

## Notes

- No changes to routing, auth keys, or `run-tailscale.sh`: client version pin and docs only.
- Operators can continue overriding `TAILSCALE_VERSION` in the Render dashboard if they need a different build.